### PR TITLE
New GeneralFunctions.cs Helper. Further StopCrafting updates. Edited Fate Escort movement.

### DIFF
--- a/Helpers/GeneralFunctions.cs
+++ b/Helpers/GeneralFunctions.cs
@@ -1,0 +1,78 @@
+﻿using Buddy.Coroutines;
+using ff14bot;
+using ff14bot.Behavior;
+using ff14bot.Helpers;
+using ff14bot.Managers;
+using ff14bot.Objects;
+using ff14bot.RemoteWindows;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Media;
+
+namespace LlamaLibrary.Helpers
+{
+    class GeneralFunctions
+    {
+        public static async Task<bool> StopCrafting()
+        {
+            for (int tryStep = 1; tryStep < 6; tryStep++)
+            {
+                if (!(DutyManager.InInstance || CraftingLog.IsOpen || FishingManager.State != FishingState.None || MovementManager.IsOccupied || CraftingManager.IsCrafting)) break;
+
+                Log($"We're occupied. Trying to exit out. Attempt #{tryStep}");
+
+                if (FishingManager.State != FishingState.None)
+                {
+                    var quit = ActionManager.CurrentActions.Values.FirstOrDefault(i => i.Id == 299);
+                    if (quit != default(SpellData))
+                    {
+                        Log($"Exiting Fishing.");
+                        if (ActionManager.CanCast(quit, Core.Me))
+                        {
+                            ActionManager.DoAction(quit, Core.Me);
+                            await Coroutine.Wait(6000, () => FishingManager.State == FishingState.None);
+                        }
+                    }
+                }
+
+                if (CraftingLog.IsOpen || CraftingManager.IsCrafting)
+                {
+                    Log($"Closing Crafting Window.");
+                    await Lisbeth.ExitCrafting();
+                    CraftingLog.Close();
+                    await Coroutine.Wait(6000, () => !CraftingLog.IsOpen);
+                    await Coroutine.Wait(6000, () => !CraftingManager.IsCrafting && !MovementManager.IsOccupied);
+                }
+
+                if (DutyManager.InInstance)
+                {
+                    Log($"Leaving Diadem.");
+                    DutyManager.LeaveActiveDuty();
+
+                    if (await Coroutine.Wait(30000, () => CommonBehaviors.IsLoading))
+                    {
+                        await Coroutine.Yield();
+                        await Coroutine.Wait(-1, () => !CommonBehaviors.IsLoading);
+                        await Coroutine.Sleep(5000);
+                    }
+                }
+
+                await Coroutine.Sleep(2500);
+            }
+
+            if (DutyManager.InInstance || CraftingLog.IsOpen || FishingManager.State != FishingState.None || MovementManager.IsOccupied || CraftingManager.IsCrafting)
+            {
+                Log("Something went wrong, we're still occupied.");
+                TreeRoot.Stop("Stopping bot.");
+                return false;
+            }
+            return true;
+        }
+
+        private static void Log(string text, params object[] args)
+        {
+            var msg = string.Format("[GeneralFunctions] " + text, args);
+            Logging.Write(Colors.Aquamarine, msg);
+        }
+    }
+}

--- a/IshgardHandinBase.cs
+++ b/IshgardHandinBase.cs
@@ -66,7 +66,7 @@ namespace LlamaLibrary
 
         public static async Task<bool> Handin()
         {
-            await StopCrafting();
+            await GeneralFunctions.StopCrafting();
             if (Translator.Language == Language.Chn)
             {
                 await HandinOld();
@@ -78,62 +78,6 @@ namespace LlamaLibrary
                 await GatheringHandin();
             }
 
-            return true;
-        }
-
-        public static async Task<bool> StopCrafting()
-        {
-            for (int tryStep = 1; tryStep < 6; tryStep++)
-            {
-                if (!(DutyManager.InInstance || CraftingLog.IsOpen || FishingManager.State != FishingState.None || MovementManager.IsOccupied || CraftingManager.IsCrafting)) break;
-
-                Log($"We're occupied. Trying to exit out. Attempt #{tryStep}");
-
-                if (FishingManager.State != FishingState.None)
-                {
-                    var quit = ActionManager.CurrentActions.Values.FirstOrDefault(i => i.Id == 299);
-                    if (quit != default(SpellData))
-                    {
-                        Log($"Exiting Fishing.");
-                        if (ActionManager.CanCast(quit, Core.Me))
-                        {
-                            ActionManager.DoAction(quit, Core.Me);
-                            await Coroutine.Wait(6000, () => FishingManager.State == FishingState.None);
-                        }
-                    }
-                }
-
-                if (CraftingLog.IsOpen || CraftingManager.IsCrafting)
-                {
-                    Log($"Closing Crafting Window.");
-                    await Lisbeth.ExitCrafting();
-                    CraftingLog.Close();
-                    await Coroutine.Wait(6000, () => !CraftingLog.IsOpen);
-                    await Coroutine.Wait(6000, () => !CraftingManager.IsCrafting && !MovementManager.IsOccupied);
-                }
-
-                if (DutyManager.InInstance)
-                {
-                    Log($"Leaving Diadem.");
-                    DutyManager.LeaveActiveDuty();
-
-                    if (await Coroutine.Wait(30000, () => CommonBehaviors.IsLoading))
-                    {
-                        await Coroutine.Yield();
-                        await Coroutine.Wait(-1, () => !CommonBehaviors.IsLoading);
-                        await Coroutine.Sleep(5000);
-                    }
-                }
-
-                await Coroutine.Sleep(2500);
-            }
-
-            if (DutyManager.InInstance || CraftingLog.IsOpen || FishingManager.State != FishingState.None || MovementManager.IsOccupied || CraftingManager.IsCrafting)
-            {
-                Log("Something went wrong, we're still occupied.");
-                TreeRoot.Stop("Stopping bot.");
-                return false;
-            }
             return true;
         }
 

--- a/IshgardHandinBase.cs
+++ b/IshgardHandinBase.cs
@@ -9,7 +9,9 @@ using ff14bot.Enums;
 using ff14bot.Helpers;
 using ff14bot.Managers;
 using ff14bot.Navigation;
+using ff14bot.Objects;
 using ff14bot.Pathing.Service_Navigation;
+using ff14bot.RemoteWindows;
 using LlamaLibrary.Extensions;
 using LlamaLibrary.Helpers;
 using LlamaLibrary.Memory;
@@ -64,6 +66,7 @@ namespace LlamaLibrary
 
         public static async Task<bool> Handin()
         {
+            await StopCrafting();
             if (Translator.Language == Language.Chn)
             {
                 await HandinOld();
@@ -75,6 +78,52 @@ namespace LlamaLibrary
                 await GatheringHandin();
             }
 
+            return true;
+        }
+
+        public static async Task<bool> StopCrafting()
+        {
+            if (FishingManager.State != FishingState.None)
+            {
+                var quit = ActionManager.CurrentActions.Values.FirstOrDefault(i => i.Id == 299);
+                if (quit != default(SpellData))
+                {
+                    Log($"Exiting Fishing");
+                    if (ActionManager.CanCast(quit, Core.Me))
+                    {
+                        ActionManager.DoAction(quit, Core.Me);
+                        await Coroutine.Wait(6000, () => FishingManager.State == FishingState.None);
+                    }
+                }
+            }
+
+            if (CraftingLog.IsOpen)
+            {
+                Log($"Closing Crafting Window");
+                await Lisbeth.ExitCrafting();
+                await Coroutine.Wait(6000, () => !CraftingLog.IsOpen);
+                await Coroutine.Wait(6000, () => !CraftingManager.IsCrafting && !MovementManager.IsOccupied);
+            }
+
+            if (DutyManager.InInstance)
+            {
+                Log($"Leaving Diadem");
+                DutyManager.LeaveActiveDuty();
+
+                if (await Coroutine.Wait(30000, () => CommonBehaviors.IsLoading))
+                {
+                    await Coroutine.Yield();
+                    await Coroutine.Wait(-1, () => !CommonBehaviors.IsLoading);
+                    await Coroutine.Sleep(5000);
+                }
+            }
+
+            if (DutyManager.InInstance || CraftingLog.IsOpen || FishingManager.State != FishingState.None || MovementManager.IsOccupied || CraftingManager.IsCrafting)
+            {
+                Log("Something went wrong.");
+                TreeRoot.Stop("Stopping bot.");
+                return false;
+            }
             return true;
         }
 

--- a/OrderbotTags/Fate.cs
+++ b/OrderbotTags/Fate.cs
@@ -394,8 +394,7 @@ namespace ff14bot.NeoProfiles
         private async Task MoveToFocusedFate()
         {
             Vector3 currentMove;
-            if (currentfate.Icon == FateIconType.ProtectNPC ||
-                  currentfate.Icon == FateIconType.ProtectNPC2)
+            if (currentfate.Icon == FateIconType.ProtectNPC || currentfate.Icon == FateIconType.ProtectNPC2)
             {
                 if (ClusterTimer.ElapsedMilliseconds > 5000)
                 {
@@ -408,7 +407,7 @@ namespace ff14bot.NeoProfiles
                     GameObjectManager.GetObjectsOfType<BattleCharacter>()
                         .Where(
                             bc =>
-                                bc.Type == GameObjectType.Pc &&
+                                ((bc.IsFate && bc.FateId == currentfate.Id && !bc.CanAttack) || bc.Type == GameObjectType.Pc) &&
                                 bc.Location.Distance(currentfate.Location) < currentfate.Radius)
                         .ForEach(
                             bc =>

--- a/Retainers/RetainersPull.cs
+++ b/Retainers/RetainersPull.cs
@@ -145,40 +145,7 @@ namespace LlamaLibrary.Retainers
 
             if (rets.Any(i => i.Active && i.VentureTask !=0 && (i.VentureEndTimestamp - now) <= 0 && SpecialCurrencyManager.GetCurrencyCount(SpecialCurrency.Venture) > 2))
             {
-                if (FishingManager.State != FishingState.None)
-                {
-                    var quit = ActionManager.CurrentActions.Values.FirstOrDefault(i => i.Id == 299);
-                    if (quit != default(SpellData))
-                    {
-                        Log($"Exiting Fishing");
-                        if (ActionManager.CanCast(quit, Core.Me))
-                        {
-                            ActionManager.DoAction(quit, Core.Me);
-                            await Coroutine.Wait(6000, () => FishingManager.State == FishingState.None);
-                        }
-                    }
-                }
-
-                if (CraftingLog.IsOpen)
-                {
-                    Log($"Closing Crafting Window");
-                    await Lisbeth.ExitCrafting();
-                    await Coroutine.Wait(6000, () => !CraftingLog.IsOpen);
-                    await Coroutine.Wait(6000, () => !CraftingManager.IsCrafting && !MovementManager.IsOccupied);
-                }
-                
-                if (DutyManager.InInstance)
-                {
-                    Log($"Leaving Diadem");
-                    DutyManager.LeaveActiveDuty();
-
-                    if (await Coroutine.Wait(30000, () => CommonBehaviors.IsLoading))
-                    {
-                        await Coroutine.Yield();
-                        await Coroutine.Wait(Timeout.Infinite, () => !CommonBehaviors.IsLoading);
-                        await Coroutine.Sleep(5000);
-                    }
-                }
+                await GeneralFunctions.StopCrafting();
 
                 if (DutyManager.InInstance || CraftingLog.IsOpen || FishingManager.State != FishingState.None || MovementManager.IsOccupied || CraftingManager.IsCrafting)
                 {


### PR DESCRIPTION
StopCrafting() has been moved to a new GeneralFunctions class, which will hopefully house any often-repeated functions used in multiple places throughout LL. RetainersPull.cs has been edited to use StopCrafting() to make use of its further updates.

StopCrafting() has been updated to utilize CraftingLog.Close() as Lisbeth.ExitCrafting() was not (appearing to) work. Will also try multiple times before giving up, just in case.

Fate tag has been given slight updates so that during Escort Fates it will count NPCs as well as PCs for moving with the fate, for when there are no other PCs around.